### PR TITLE
Update CVE-2021-42306-AutomationAssessAndMitigate.ps1

### DIFF
--- a/azure-automation/CVE-2021-42306-AutomationAssessAndMitigate.ps1
+++ b/azure-automation/CVE-2021-42306-AutomationAssessAndMitigate.ps1
@@ -135,39 +135,43 @@ function Assess-Impact {
     Write-Output "Started Assessing impacted Automation accounts..."
     Write-Output "================================================="
 
-    # Get all automation accounts accessible to current user
-    $queryPayload = @{
-        query = 'resources | where type == "microsoft.automation/automationaccounts"'
-        options = @{
-        '$top' = 10000
-        '$skip' = 0
-        '$skipToken' = ""
-        'resultFormat' = "table"
-        }
-    }
-    $payload = $queryPayload | ConvertTo-Json
-
-    $resp = Invoke-AzRestMethod -Path "/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01" -Method POST -Payload $payload
-    $resp = $resp.Content | ConvertFrom-Json
-
     $allAccounts = New-Object System.Collections.ArrayList
-    $defaultDate = (Get-Date 01-01-1970)
-    foreach ($row in $resp.data.rows)
-    {
-        $a = [AutomationAccount]@{
-            ResourceId = $row[0]
-            Name = $row[1]
-            Region = $row[5]
-            ResourceGroup = $row[6]
-            SubscriptionId = $row[7]
-            RunAsAppId = ""
-            RunAsConnectionCreationTime = $defaultDate
-            UsesThirdParytCert = $false
+    $skipToken = $null
+    do {
+        # Get all automation accounts accessible to current user
+        $queryPayload = @{
+            query = 'resources | where type == "microsoft.automation/automationaccounts"'
+            options = @{
+            '$top' = 1000
+            '$skipToken' = $skipToken
+            'resultFormat' = "table"
+            }
         }
-        Write-Debug "$($a.Name), $($a.Region), $($a.ResourceGroup), $($a.SubscriptionId)"
+        $payload = $queryPayload | ConvertTo-Json
 
-        $allAccounts.Add($a) > $null
-    }
+        $resp = Invoke-AzRestMethod -Path "/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01" -Method POST -Payload $payload
+        $resp = $resp.Content | ConvertFrom-Json
+
+    
+        $defaultDate = (Get-Date 01-01-1970)
+        foreach ($row in $resp.data.rows)
+        {
+            $a = [AutomationAccount]@{
+                ResourceId = $row[0]
+                Name = $row[1]
+                Region = $row[5]
+                ResourceGroup = $row[6]
+                SubscriptionId = $row[7]
+                RunAsAppId = ""
+                RunAsConnectionCreationTime = $defaultDate
+                UsesThirdParytCert = $false
+            }
+            Write-Debug "$($a.Name), $($a.Region), $($a.ResourceGroup), $($a.SubscriptionId)"
+
+            $allAccounts.Add($a) > $null
+        }
+        $skipToken = $resp.'$skipToken'
+    } until (!$skipToken)
 
     Assess-ImpactBySubscriptionGroup $allAccounts
     Write-Output ""
@@ -315,6 +319,8 @@ Function Make-MSGraphRequest
         [bool]
         $AddConsistencyLevel
     )
+
+    $MsGraphToken = (Get-AzAccessToken -ResourceUrl $MsGraphEndpoint).Token
 
     $headers = @{
         "Authorization" = "Bearer $($MsGraphToken)"
@@ -558,7 +564,6 @@ Show-Description
 
 Connect-AzAccount -Environment $Env -ErrorAction Stop > $null
 $MsGraphEndpoint = Get-MSGraphEndpoint $Env
-$MsGraphToken = (Get-AzAccessToken -ResourceUrl $MsGraphEndpoint).Token
 
 if(![string]::IsNullOrWhiteSpace($AppId)){
     Write-Output "Start Assessment for given AAD AppID."


### PR DESCRIPTION
Updated the code to include next page query for getting all automation accounts, as if more than 1000 accounts are accessible to current user, they are not added to collection. Using top = 10000 didn't work as result set cannot exceed maximum value of 1000 returned records:
https://docs.microsoft.com/en-us/azure/governance/resource-graph/concepts/work-with-data#paging-results

Execution of Get-AzAccessToken cmdlet was moved from beginning of the script to Make-MSGraphRequest function to ensure access token is being refreshed. In other case script is failing if it is running for more than 1 hour (beyond the lifetime of the initially obtained access token), as there is no validation if access token is not expired.