### PR TITLE
Minor fix - Change 'MS Graph' to 'Microsoft Graph'

### DIFF
--- a/azure-automation/CVE-2021-42306-AutomationAssessAndMitigate.ps1
+++ b/azure-automation/CVE-2021-42306-AutomationAssessAndMitigate.ps1
@@ -71,7 +71,7 @@ Param(
     [string]
     $AppId,
 
-    # Max number of retries for List Applications or List ServicePrincipals MS Graph request
+    # Max number of retries for List Applications or List ServicePrincipals Microsoft Graph request
     [int]
     $MaxRetryLimitForGraphApiCalls = 5,
 
@@ -299,7 +299,7 @@ Function Trim-Url
     return $Url -replace '`n','' -replace '\s+', ''
 }
 
-# Make MS Graph request with retry and exponential backoff
+# Make Microsoft Graph request with retry and exponential backoff
 Function Make-MSGraphRequest
 {
     param(

--- a/azuread/azuread-app-credential-remediation-guide.md
+++ b/azuread/azuread-app-credential-remediation-guide.md
@@ -6,12 +6,12 @@ Guidance in this document applies only in relation to the mitigation steps neces
 
 ## Assessment
 
-There are a few ways by which you can find if the credential(s) on your application or service principal need to be rotated.
+There are a few ways to assess whether the credential(s) on your application or service principal need to be rotated.
 
 | **Assessment method**                             | **Credential assessment guide**                                                                                   |
 | -------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| KeyCredential assessment using MS Graph API  (recommended)               | [Application credential assessment using MS Graph API](azuread-application-credential-assessment-msgraph-guide.md)                   |
-| KeyCredential assessment PowerShell module for MS Graph API               | [Application credential assessment PowerShell module](azuread-application-credential-assessment-powershell-guide.md)                   |
+| KeyCredential assessment using Microsoft Graph API  (recommended)               | [Application credential assessment using Microsoft Graph API](azuread-application-credential-assessment-msgraph-guide.md)                   |
+| KeyCredential assessment PowerShell module for Microsoft Graph API               | [Application credential assessment PowerShell module](azuread-application-credential-assessment-powershell-guide.md)                   |
 | Azure Sentinel (license required)                | [Application credential assessment using Azure Sentinel notebook](azuread-application-credential-assessment-sentinel-guide.md)                   |
 
 ## Remediation
@@ -24,6 +24,6 @@ If the credential that needs to be rotated is expired, you can skip the steps to
 | **Rotation method**                             | **Credential rotation guide**                                                                                   |
 | -------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | Azure AD Toolkit for applications and service principals (recommended)               | [Application credential rotation using Azure AD Toolkit](azuread-application-credential-rotation-azuread-toolkit-guide.md)                   |
-| MS Graph application and service principal APIs                 | [Application credential rotation using MS Graph API](azuread-application-credential-rotation-msgraph-guide.md)                   |
+| Microsoft Graph application and service principal APIs                 | [Application credential rotation using Microsoft Graph API](azuread-application-credential-rotation-msgraph-guide.md)                   |
 | Azure portal (for application object only)                 | [Application only credential rotation using Azure portal](azuread-application-only-credential-rotation-azure-portal-guide.md)                   |
 

--- a/azuread/azuread-application-credential-assessment-msgraph-guide.md
+++ b/azuread/azuread-application-credential-assessment-msgraph-guide.md
@@ -1,12 +1,12 @@
-# MS Graph API (recommended)
+# Microsoft Graph API (recommended)
 
-You can use MS Graph application and service principal APIs to get the application or service principal resources that need to be assessed. The keyCredential object in the application api has a new property ‘hasExtendedValue’ which indicates the need to rotate the credential. The following points are crucial to conducting an accurate assessment for your applications.
+You can use Microsoft Graph application and service principal APIs to get the application or service principal resources that need to be assessed. The **keyCredential** object in the application API has a new property **hasExtendedValue** which indicates the need to rotate the credential. The following points are crucial to conducting an accurate assessment for your applications.
 
-- The call to get an application or service principal requires the use of **`$select`** query parameter to get accurate result for the **`hasExtendedValue`** property.
-- If the APIs are called without the query parameters, the property `hasExtendedValue` will default to null and should not be interpreted as a false.
-- For a given credential if the value of `hasExtendedValue` is true, it signifies the presence of private key data and that keyCredential must be rotated.
-- The property is available only in the MS Graph beta endpoint.
-- This new property will not be part of the MS Graph beta schema.
+- The call to get an application or service principal requires the use of the `$select` query parameter to get the correct value for the **hasExtendedValue** property.
+- If the APIs are called without the query parameters, the property **hasExtendedValue** will default to `null` and should not be interpreted as `false`.
+- For a given credential if the value of **hasExtendedValue** is `true`, it signifies the presence of private key data and that keyCredential must be rotated.
+- The property is available only in the Microsoft Graph `beta` endpoint.
+- This new property will not be part of the Microsoft Graph `beta` schema.
 
 Here are the details of the request and sample response:
 

--- a/azuread/azuread-application-credential-assessment-powershell-guide.md
+++ b/azuread/azuread-application-credential-assessment-powershell-guide.md
@@ -1,7 +1,7 @@
-# KeyCredential assessment PowerShell module for MS Graph API
+# KeyCredential assessment PowerShell module for Microsoft Graph API
 
 Run the Azure AD App credential key scanner PowerShell module to find out if credential(s) of an application or service principal need to be rotated.
-This module calls the MS Graph application API and reads the `hasExtendedValue` property as described in the '**Use MS Graph API**' assessment section.
+This module calls the Microsoft Graph application API and reads the **hasExtendedValue** property as described in the '**Use Microsoft Graph API**' assessment section.
 
 We recommend importing the module each time you run it, to make sure you are working with the latest version of the script.
 
@@ -31,9 +31,9 @@ We recommend importing the module each time you run it, to make sure you are wor
 
 | **Parameter** |**Description**|
 |---|---|
-|-PageSize| The size of each page returned per MS graph request (aka the value for $top. 200 by default).|
-|-SleepInterval| The sleep duration in seconds between the paginated MS graph requests (2 by default).|
-|-MaxRetryLimit| The maximum number of retries if MS Graph returns 429. (3 by default).|
+|-PageSize| The size of each page returned per Microsoft Graph request (aka the value for $top. 200 by default).|
+|-SleepInterval| The sleep duration in seconds between the paginated Microsoft Graph requests (2 by default).|
+|-MaxRetryLimit| The maximum number of retries if Microsoft Graph returns `429 Too Many Requests` error code. (3 by default).|
 |-MaxPageSize| The maximum limit for PageSize (500 by default).|
 |<img width=200/>|<img width=500/>|
 

--- a/azuread/azuread-application-credential-rotation-msgraph-guide.md
+++ b/azuread/azuread-application-credential-rotation-msgraph-guide.md
@@ -1,4 +1,4 @@
-# Application credential rotation using MS Graph API
+# Application credential rotation using Microsoft Graph API
 
 **Artifacts**
 
@@ -130,10 +130,10 @@ PATCH body:
 
 5. Repeat steps 1-4 for Service Principal object(s) associated with the above application.
 
-6. Use the AAD key cred scanner PowerShell module or MS Graph API to ensure your newly added credential does not contain any private key information.
+6. Use the AAD key cred scanner PowerShell module or Microsoft Graph API to ensure your newly added credential does not contain any private key information.
 
 7. Review the guidance under [Credential Review](credentials-review.md) document.
 
 > [!Note]
-> You can also achieve the desired key rotation results by following the steps described above by using [MS Graph PowerShell modules](https://docs.microsoft.com/en-us/graph/powershell/installation?context=graph%2Fapi%2F1.0&view=graph-rest-1.0).
+> You can also achieve the desired key rotation results by following the steps described above by using [Microsoft Graph PowerShell modules](https://docs.microsoft.com/en-us/graph/powershell/installation?context=graph%2Fapi%2F1.0&view=graph-rest-1.0).
 

--- a/azuread/azuread-application-only-credential-rotation-azure-portal-guide.md
+++ b/azuread/azuread-application-only-credential-rotation-azure-portal-guide.md
@@ -1,8 +1,8 @@
-# Azure portal (does not work for Service principal)
+# Azure portal (does not work for Service principalS)
 
 > [!Note]
 > This option should only be used for application object credential rotation and does not work for Service principal credential rotation.
-> To manage credentials on service principal object(s), you must use MS Graph API, MS Graph PowerShell modules or the Azure AD toolkit.
+> To manage credentials on service principal object(s), you must use Microsoft Graph API, Microsoft Graph PowerShell modules or the Azure AD toolkit.
 
 **(a)** Navigate to Azure Portal and switch to the relevant directory.
 


### PR DESCRIPTION
As per the Microsoft cloud style guide (https://styleguides.azurewebsites.net/Styleguide/Read?id=2696&topicid=39380), 'Microsoft Graph' should never be abbreviated.